### PR TITLE
fix: remove 'grunt-responsive-images' from 'dependencies' 

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,5 @@
     "grunt-contrib-nodeunit": "~0.4.1",
     "grunt-contrib-uglify": "~0.5.0",
     "grunt-responsive-images": "^0.1.6"
-  },
-  "dependencies": {
-    "grunt-responsive-images": "^0.1.6"
   }
 }


### PR DESCRIPTION
It seems that `grunt-responsive-images` is a package that is only required in the development phase, and therefore should be removed from 'dependancies' in 'package.json' as it is already included in 'devDependencies'.

Please correct my understanding if I'm wrong! I was reading the NPM doc and this stack answer.

http://stackoverflow.com/questions/18875674/whats-the-difference-between-dependencies-devdependencies-and-peerdependencies

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/udacity/responsive-images/9)

<!-- Reviewable:end -->
