### PR TITLE
Replace 'something?' error message on CSP failure

### DIFF
--- a/project/project-grader.js
+++ b/project/project-grader.js
@@ -52,12 +52,12 @@
         req.open('GET', url, true);
         req.onloadend = fireLoadEvent;
         req.onerror = function() {
-          console.log('something?');
+          console.log("If you're seeing this error, you might need to serve the site through http://localhost.");
         }
         req.send();
       } catch (e) {
         console.log(e);
-        throw new Error("If you're seeing this error, you might need to serve the site through localhost.")
+        throw new Error("If you're seeing this error, you might need to serve the site through http://localhost.")
       }
     }
 


### PR DESCRIPTION
Great course (as some others by Cam). Chrome showed the `something?` message if the page was loaded from a file URL. Copying the error message to `onerror` (modulo refactoring, but it's your code) could ease the debugging for those who omitted to "Just Read the Instructions".